### PR TITLE
Add feat to set traffic minimum rate optionally

### DIFF
--- a/api/v1/policy_targettracking_type.go
+++ b/api/v1/policy_targettracking_type.go
@@ -5,10 +5,9 @@ type TargetTrackingPolicy struct {
 	BaseValue   int64 `json:"baseValue"`
 
 	// +optional
-	DisableScaleIn bool `json:"disableScaleIn,omitempty"`
-
-	// +optional
-	Scheduled []Scheduled `json:"scheduled,omitempty"`
+	DisableScaleIn bool        `json:"disableScaleIn,omitempty"`
+	Scheduled      []Scheduled `json:"scheduled,omitempty"`
+	Minimum        int64       `json:"minimum,omitempty"`
 }
 
 type Scheduled struct {

--- a/config/crd/bases/rebalancer.ch1aki.github.io_rebalances.yaml
+++ b/config/crd/bases/rebalancer.ch1aki.github.io_rebalances.yaml
@@ -138,6 +138,9 @@ spec:
                         type: integer
                       disableScaleIn:
                         type: boolean
+                      minimum:
+                        format: int64
+                        type: integer
                       scheduled:
                         items:
                           properties:

--- a/controllers/policy/targettracking/policy.go
+++ b/controllers/policy/targettracking/policy.go
@@ -19,6 +19,7 @@ type Policy struct {
 	baseValue           int64
 	disableScaleIn      bool
 	scheduled           []rebalancev1.Scheduled
+	minimum             int64
 }
 
 func (p *Policy) New(rebalance *rebalancev1.Rebalance, target *rebalancev1.TargetClient,
@@ -31,6 +32,7 @@ func (p *Policy) New(rebalance *rebalancev1.Rebalance, target *rebalancev1.Targe
 		baseValue:           rebalance.Spec.Policy.TargetTracking.BaseValue,
 		disableScaleIn:      rebalance.Spec.Policy.TargetTracking.DisableScaleIn,
 		scheduled:           rebalance.Spec.Policy.TargetTracking.Scheduled,
+		minimum:             rebalance.Spec.Policy.TargetTracking.Minimum,
 	}, nil
 }
 
@@ -43,6 +45,10 @@ func (p *Policy) Estimate(ctx context.Context) (int64, error) {
 
 	// process desired value
 	val := processBestContrast(float64(p.baseValue), float64(p.trackingTargetValue), currentMetric)
+	minimum := p.minimum
+	if val < minimum {
+		val = minimum
+	}
 
 	// check scheduled values
 	if len(p.scheduled) > 0 {


### PR DESCRIPTION
トラフィックを流す最小割合を指定できるようにします。

```
spec:
  dryRun: false
  interval: 1m
  policy:
    targettracking:
      targetValue: 1
      baseValue: 100
      minimum: 1
```

例えばminimumに`1`を指定したら、変更されるweightは1を下回らなくなります。
常にある程度のトラフィックを流しておきたいときに便利です。